### PR TITLE
 Upload Bootstrapped Repository

### DIFF
--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -4,6 +4,7 @@ jobs:
     timeoutInMinutes: 180
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+      IsBuild: true
     pool:
       vmImage: ubuntu-16.04
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -9,6 +9,7 @@ jobs:
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
       RunCoreMainTests: true
+      IsBuild: true
     pool:
       vmImage: macos-10.15
 

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -32,5 +32,5 @@ steps:
       artifacts:
         - path: '.'
           condition: and(succeeded(), eq(variables.IsBuild, 'true'))
-          archiveFileName: bootstrapped_repository_$(AGENT_OS)_$(buildArch).7z
+          archiveFileName: bootstrapped_repository_$(Agent.OS)_$(buildArch).7z
           archiveDir: $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -32,5 +32,5 @@ steps:
       artifacts:
         - path: '.'
           condition: and(succeeded(), eq(variables.IsBuild, 'true'))
-          archiveFileName: bootstrapped_repository_$(Agent.OS)_$(buildArch).7z
+          archiveFileName: bootstrapped_repository_$(Agent.OS)_$(BUILD_ARCH).7z
           archiveDir: $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -31,4 +31,4 @@ steps:
     parameters:
       artifacts:
         - path: '.'
-          condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
+          condition: succeeded()

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -24,3 +24,11 @@ steps:
       CI: true
       CI_PROVIDER: VSTS
     condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptRunnerNodeModulesRestored'], true), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'), ne(variables['LocalPackagesRestored'], 'true'))
+
+  # upload bootstraped repository
+  # to provide a ready development environment (similar to a pre-built docker image)
+  - template: ./zip-upload.yml
+    parameters:
+      artifacts:
+        - path: '.'
+          condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -31,6 +31,6 @@ steps:
     parameters:
       artifacts:
         - path: '.'
-          condition: succeeded()
+          condition: and(succeeded(), eq(variables.IsBuild, 'true'))
           archiveFileName: bootstrapped_repository_$(AGENT_OS)_$(buildArch).7z
           archiveDir: $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -32,3 +32,5 @@ steps:
       artifacts:
         - path: '.'
           condition: succeeded()
+          archiveFileName: bootstrapped_repository_$(AGENT_OS)_$(buildArch).7z
+          archiveDir: $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/templates/zip-upload.yml
+++ b/script/vsts/platforms/templates/zip-upload.yml
@@ -15,7 +15,7 @@ steps:
       inputs:
         rootFolderOrFile: ${{artifact.path}}
         archiveType: 7z
-        sevenZipCompression: ultra
+        sevenZipCompression: normal
         archiveFile: ${{artifact.archiveDir}}/${{artifact.archiveFileName}}
         replaceExistingArchive: true
       displayName: Compress ${{artifact.path}}

--- a/script/vsts/platforms/templates/zip-upload.yml
+++ b/script/vsts/platforms/templates/zip-upload.yml
@@ -1,0 +1,34 @@
+parameters:
+  # artifacts files or directory
+  # props:
+  # - path
+  # - condition
+  - name: artifacts
+    type: object
+    default: {}
+  # the path to store the 7z file
+  # the file is overwritten for each artifact
+  - name: uploadPath
+    type: string
+    default: $(Build.ArtifactStagingDirectory)/artifact_zip_upload.7z
+
+steps:
+  - ${{ each artifact in parameters.artifacts }}:
+    - task: ArchiveFiles@2
+      inputs:
+        rootFolderOrFile: ${{artifact.path}}
+        archiveType: 7z
+        sevenZipCompression: ultra
+        archiveFile: ${{parameters.uploadPath}}
+        replaceExistingArchive: true
+      displayName: Compress ${{artifact.path}}
+      ${{ if artifact.condition }}:
+        condition: ${{artifact.condition}}
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: ${{parameters.uploadPath}}
+        ArtifactName: ${{artifact.path}}
+      displayName: Upload ${{artifact.path}}
+      ${{ if artifact.condition }}:
+        condition: ${{artifact.condition}}

--- a/script/vsts/platforms/templates/zip-upload.yml
+++ b/script/vsts/platforms/templates/zip-upload.yml
@@ -3,14 +3,11 @@ parameters:
   # props:
   # - path
   # - condition
+  # - archiveFileName
+  # - archiveDir
   - name: artifacts
     type: object
     default: {}
-  # the path to store the 7z file
-  # the file is overwritten for each artifact
-  - name: uploadPath
-    type: string
-    default: $(Build.ArtifactStagingDirectory)/artifact_zip_upload.7z
 
 steps:
   - ${{ each artifact in parameters.artifacts }}:
@@ -19,16 +16,16 @@ steps:
         rootFolderOrFile: ${{artifact.path}}
         archiveType: 7z
         sevenZipCompression: ultra
-        archiveFile: ${{parameters.uploadPath}}
+        archiveFile: ${{artifact.archiveDir}}/${{artifact.archiveFileName}}
         replaceExistingArchive: true
       displayName: Compress ${{artifact.path}}
       ${{ if artifact.condition }}:
         condition: ${{artifact.condition}}
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: ${{parameters.uploadPath}}
-        ArtifactName: ${{artifact.path}}
-      displayName: Upload ${{artifact.path}}
-      ${{ if artifact.condition }}:
-        condition: ${{artifact.condition}}
+    - template: ./publish.yml
+      parameters:
+        artifacts:
+          - filename: ${{artifact.archiveFileName}}
+            dir: ${{artifact.archiveDir}}
+            ${{ if artifact.condition }}:
+              condition: ${{artifact.condition}}

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -21,6 +21,7 @@ jobs:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+      IsBuild: true
 
     steps:
       - template: templates/preparation.yml


### PR DESCRIPTION
### Description of the change

This adds a step to the release CI that uploads the ready bootstrapped repository. This provides a ready development environment for people to start hacking Atom's Core without running and dealing with the bootstrap script (similar to a pre-built docker images).

### Verification 
The CI passes 