### PR TITLE
Always restore cache

### DIFF
--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -9,7 +9,7 @@ module.exports = function(ci) {
   // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
     CONFIG.getNpmBinPath(),
-    ['--global-style', '--loglevel=error', 'install'],
+    ['--global-style', '--loglevel=error', 'install', ci ? '--no-save' : ''],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
 };

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -9,8 +9,8 @@ process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 module.exports = function(ci) {
   console.log('Installing script dependencies');
   childProcess.execFileSync(
-    CONFIG.getNpmBinPath(ci),
-    ['--loglevel=error', ci ? 'ci' : 'install'],
+    CONFIG.getNpmBinPath(),
+    ['--loglevel=error', 'install'],
     { env: process.env, cwd: CONFIG.scriptRootPath }
   );
 };

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -11,7 +11,7 @@ module.exports = function(packagePath, ci, stdioOptions) {
   // Set our target (Electron) version so that node-pre-gyp can download the
   // proper binaries.
   installEnv.npm_config_target = CONFIG.appMetadata.electronVersion;
-  childProcess.execFileSync(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
+  childProcess.execFileSync(CONFIG.getApmBinPath(), ['install'], {
     env: installEnv,
     cwd: packagePath,
     stdio: stdioOptions || 'inherit'

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -11,7 +11,7 @@ module.exports = function(packagePath, ci, stdioOptions) {
   // Set our target (Electron) version so that node-pre-gyp can download the
   // proper binaries.
   installEnv.npm_config_target = CONFIG.appMetadata.electronVersion;
-  childProcess.execFileSync(CONFIG.getApmBinPath(), ['install'], {
+  childProcess.execFileSync(CONFIG.getApmBinPath(), ['install', ci ? '--no-save' : ''], {
     env: installEnv,
     cwd: packagePath,
     stdio: stdioOptions || 'inherit'

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -11,9 +11,13 @@ module.exports = function(packagePath, ci, stdioOptions) {
   // Set our target (Electron) version so that node-pre-gyp can download the
   // proper binaries.
   installEnv.npm_config_target = CONFIG.appMetadata.electronVersion;
-  childProcess.execFileSync(CONFIG.getApmBinPath(), ['install', ci ? '--no-save' : ''], {
-    env: installEnv,
-    cwd: packagePath,
-    stdio: stdioOptions || 'inherit'
-  });
+  childProcess.execFileSync(
+    CONFIG.getApmBinPath(),
+    ['install', ci ? '--no-save' : ''],
+    {
+      env: installEnv,
+      cwd: packagePath,
+      stdio: stdioOptions || 'inherit'
+    }
+  );
 };

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -12,6 +12,9 @@ steps:
     displayName: Cache node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
@@ -19,6 +22,9 @@ steps:
     displayName: Cache script/node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
@@ -26,5 +32,8 @@ steps:
     displayName: Cache apm/node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,7 +11,7 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/templates/preparation.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
@@ -21,7 +21,7 @@ steps:
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/templates/preparation.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
@@ -31,7 +31,7 @@ steps:
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/templates/preparation.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -13,8 +13,8 @@ steps:
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
@@ -23,8 +23,8 @@ steps:
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
@@ -33,7 +33,7 @@ steps:
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json
-         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,7 +11,7 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
@@ -21,7 +21,7 @@ steps:
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
@@ -31,7 +31,7 @@ steps:
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/templates/preparation.yml, script/vsts/platforms/${{ parameters.OS }}.yml'
       restoreKeys: |
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"


### PR DESCRIPTION
### Edit: turns out `npm ci` deletes all the restored cache. This PR means we should decide between the reliability of CI vs the time it takes to bootstrap

We should restore the `node_modules` cache even if we change package.json. `npm install` is smart enough to not redo everything from scratch! In this case, however, we should not skip the bootstrap phase completely. It will automatically become faster due to npm's smartness.

This branch is based on #31. Needs rebase and adding it for other platforms for final merging.