### PR TITLE
Updating readme to be more clear w/upstream sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://dev.azure.com/github/Atom/_apis/build/status/Atom%20Production%20Branches?branchName=master)](https://dev.azure.com/github/Atom/_build/latest?definitionId=32&branchName=master)
 
-> Due to changes in focus The upstream Atom  and all it's repositories under the original Atom branding will be archived on December 15, 2022. Get involved here while we work on the future of Atom-community. You can learn more in their [official announcement](https://github.blog/2022-06-08-sunsetting-atom/) and get involved here.
+> Due to changes in the upstream, Atom and all it's repositories under the original Atom branding will be archived on December 15, 2022. Get involved here while we work on the future of Atom-community. You can learn more in their [official announcement](https://github.blog/2022-06-08-sunsetting-atom/) and get involved here.
 
 Atom is a hackable text editor for the 21st century, built on [Electron](https://github.com/electron/electron), and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://dev.azure.com/github/Atom/_apis/build/status/Atom%20Production%20Branches?branchName=master)](https://dev.azure.com/github/Atom/_build/latest?definitionId=32&branchName=master)
 
-> Atom and all repositories under Atom will be archived on December 15, 2022. Learn more in our [official announcement](https://github.blog/2022-06-08-sunsetting-atom/)
+> Due to changes in focus The upstream Atom  and all it's repositories under the original Atom branding will be archived on December 15, 2022. Get involved here while we work on the future of Atom-community. You can learn more in their [official announcement](https://github.blog/2022-06-08-sunsetting-atom/) and get involved here.
 
 Atom is a hackable text editor for the 21st century, built on [Electron](https://github.com/electron/electron), and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://dev.azure.com/github/Atom/_apis/build/status/Atom%20Production%20Branches?branchName=master)](https://dev.azure.com/github/Atom/_build/latest?definitionId=32&branchName=master)
 
-> Due to changes in the upstream, Atom and all it's repositories under the original Atom branding will be archived on December 15, 2022. Get involved here while we work on the future of Atom-community. You can learn more in their [official announcement](https://github.blog/2022-06-08-sunsetting-atom/) and get involved here.
+> Due to upstream changes, [Atom and all repositories under the original Atom branding will be archived on December 15, 2022](https://github.blog/2022-06-08-sunsetting-atom/). Get involved here and at [the discord](https://discord.gg/deuBJaqVud) while we work on the future of Atom-community.
 
 Atom is a hackable text editor for the 21st century, built on [Electron](https://github.com/electron/electron), and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.
 


### PR DESCRIPTION
Since the upstream is sunsetting but it seems development is continuing here I thought it might be a good idea to update the readme to be more clear with the note at the top that it means the upstream Atom repo's and not the atom-community ones or whatever this may end up being called in the future.

Anyone can change this wording because I'm not sure I've done it justice but it feels like this is a first step that needs to be done whenever possible. I'm putting this here as a starting point for this and there's probably other edits that need to be done maybe for now importing the wiki/docs to a github wiki?
