### PR TITLE
CI: Bump Node to 12.18.3 to match Electron 11

### DIFF
--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -26,9 +26,9 @@ steps:
 
   - task: NodeTool@0
     inputs:
-      versionSpec: 12.16.3
+      versionSpec: 12.18.3
       force32bit: $(IsWinX86)
-    displayName: Install Node.js 12.16.3
+    displayName: Install Node.js 12.18.3
 
   - script: npm install --global npm@6.14.8
     displayName: Update npm


### PR DESCRIPTION
### Identify the Bug

We are using older Node 12.16.3 in CI.

(Which coincidentally matches Electron 10... but I think that's just a coincidence of updating to the latest Node LTS 12 version at around the same time Electron 10 came out.)

Using newer Node in the same line is better for bug fixes. Using the same version of Node our Electron version is based off of theoretically has some benefits, although I'm not super clear on what they are, there's also no harm in it other than missing out on even newer releases (for example 12.22.12.)

### Description of the Change

Update Node in CI from 12.16.3 to the slightly newer 12.18.3, which [matches Electron 11](https://www.electronjs.org/releases/stable?version=11&page=6#11.0.0) as currently used in the fork's `master` branch.

### Alternate Designs

None considered.

### Possible Drawbacks

None anticipated.

If CI passes, this should be strictly an improvement with regard to minor bugfixes and improvements in Node. And only in terms of the environment scripts are run in in CI. In theory, this should not affect the final built editor whatsoever.

### Verification Process

Will run CI to confirm good behavior.

### Release Notes

N/A