### PR TITLE
deps: Bump minidump (0.22.0 to 0.23.0) in script/

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6153,9 +6153,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/minidump/-/minidump-0.22.0.tgz",
-      "integrity": "sha512-6gg9AgtjzACB5WsDu/jzQ4Fn1s4LENhgN0vTH3RyeWlpNuXnjwviEWX//VgimEyqMVdnRynry+8aZUAtLIUXCQ=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/minidump/-/minidump-0.23.0.tgz",
+      "integrity": "sha512-swBpCYvmEFd6MER1HTNtHCySWWkb1KNY3cWNxDfOYJY0fmpwycciitys21ApGruThVTdhQ41T4pi4h7EzCJXww=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "^0.22.0",
+    "minidump": "^0.23.0",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
### Identify the Bug

Fixes: https://github.com/atom-community/atom/issues/363

### Description of the Change

Bump minidump from 0.22.0 to 0.23.0 in script/package.json

### Alternate Designs

None

### Possible Drawbacks

None expected.

### Verification Process

https://github.com/atom-community/atom/issues/363 seems to be fixed by updating `minidump` to the latest version, in `script/package.json`. 0.22.0 --> 0.23.0

<details>

I tested this in a fresh install of the latest [Manjaro Linux](https://manjaro.org/), which is a type of Arch Linux. I got the same error situation as @DAC324 reported.

I tried debugging it. `dump_syms` had blank output on stdout and stderr, so that is why there was no detailed or helpful error message being printed. The binary being spawned really had no output. I think it's fixed by this upstream commit of breakpad? ["avoid dump_syms crashing if selected arch is not found"](https://chromium.googlesource.com/breakpad/breakpad/+/c85eb4a59b618f3beaad5445ceb1f865ffa8efdf)... Maybe.

Something about the way `dump_syms` exited made it hard to catch and handle properly, I guess. So it "leaked through" and halted the build script, even though we're supposed to be handling (ignoring) the error. 

In any case, it works for me now with updated `minidump`.

</details>

### Release Notes

deps: Bump minidump from 0.22.0 to 0.23.0 in script/package.json