### PR TITLE
Bump tree sitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "temp": "0.9.2",
     "text-buffer": "^13.18.5",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "git+https://github.com/DeeDeeG/node-tree-sitter.git#bb298eaae66e0c4f11908cb6209f3e141884e88e",
+    "tree-sitter": "^0.20.0",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.229.1/tarball",
     "typescript-simple": "8.0.6",
     "update-package-dependencies": "file:./packages/update-package-dependencies",

--- a/packages/language-c/package.json
+++ b/packages/language-c/package.json
@@ -20,8 +20,8 @@
     "node": "*"
   },
   "dependencies": {
-    "tree-sitter-c": "0.19.0",
-    "tree-sitter-cpp": "0.19.0"
+    "tree-sitter-c": "0.20.1",
+    "tree-sitter-cpp": "0.20.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/packages/language-html/package.json
+++ b/packages/language-html/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-embedded-template": "^0.15.2",
-    "tree-sitter-html": "^0.15.0"
+    "tree-sitter-embedded-template": "0.19.0",
+    "tree-sitter-html": "0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1",

--- a/packages/language-java/package.json
+++ b/packages/language-java/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-java/issues"
   },
   "dependencies": {
-    "tree-sitter-java-dev": "^0.16.0-dev2"
+    "tree-sitter-java": "0.19.1"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/packages/language-json/package.json
+++ b/packages/language-json/package.json
@@ -19,6 +19,6 @@
     "coffeelint": "^1.10.1"
   },
   "dependencies": {
-    "tree-sitter-json": "^0.15.1"
+    "tree-sitter-json": "0.20.0"
   }
 }

--- a/packages/language-python/package.json
+++ b/packages/language-python/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.4",
-    "tree-sitter-python": "^0.17.0"
+    "tree-sitter-python": "0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/packages/language-ruby/package.json
+++ b/packages/language-ruby/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.17.0"
+    "tree-sitter-ruby": "^0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1",

--- a/packages/language-rust-bundled/package.json
+++ b/packages/language-rust-bundled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-rust-bundled",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rust support for Atom",
   "keywords": [
     "language",
@@ -11,7 +11,7 @@
   "repository": "https://github.com/atom/atom",
   "license": "MIT",
   "dependencies": {
-    "tree-sitter-rust": "^0.17.0"
+    "tree-sitter-rust": "0.20.1"
   },
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/packages/language-shellscript/package.json
+++ b/packages/language-shellscript/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/atom/language-shellscript/issues"
   },
   "dependencies": {
-    "tree-sitter-bash": "^0.16.1"
+    "tree-sitter-bash": "0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/packages/language-typescript/package.json
+++ b/packages/language-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TypeScript language support in Atom",
   "keywords": [
     "tree-sitter"
@@ -20,6 +20,6 @@
     "url": "https://github.com/atom/language-typescript/issues"
   },
   "dependencies": {
-    "tree-sitter-typescript": "^0.16.1"
+    "tree-sitter-typescript": "0.20.1"
   }
 }


### PR DESCRIPTION
Please, merge after this PR otherwise grammars will break: https://github.com/atom-community/atom/pull/399

This PR bumps tree-sitter to a recent version. It also uses "NPM's tree sitter", not an Atom/git specific one.

I know this code works with Electron 12. Unfortunately, `./script/bootstrap` and friends do not work on my machine, so I have no way of testing if the "current way" of building Atom also works...

Also, this PR is basically https://github.com/atom-community/atom/pull/386, but splitted into bumping tree-sitter. I'll open another bumping Electron (but it's also dependent on this one, unfortunately)