### PR TITLE
Update retirement badge for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Badge License]][License]    
 [![Badge Guidelines]][Guidelines]    
-[![Badge Retired]][Retired]    
+[![Badge Retired]][Upstream Retiring soon]    
 [![Badge Discord]][Discord]
 
 <br>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 
 [![Badge License]][License]    
 [![Badge Guidelines]][Guidelines]    
-[![Badge Retired]][Upstream Retiring soon]    
+[![Badge Retired]][Retired]
 [![Badge Discord]][Discord]
+
+<br>
+The retirement badge is regarding our UPSTREAM parent only. We are NOT retiring, infact we are in active and invite you to join in as we make this jump to our own project independent from them in the coming future after archival is done.
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@
 
 [![Badge License]][License]    
 [![Badge Guidelines]][Guidelines]    
-[![Badge Retired]][Retired]
+[![Badge Sunset]][Retired]
 [![Badge Discord]][Discord]
-
-<br>
-The retirement badge is regarding our UPSTREAM parent only. We are NOT retiring, infact we are in active and invite you to join in as we make this jump to our own project independent from them in the coming future after archival is done.
 
 <br>
 <br>
@@ -69,7 +66,8 @@ The retirement badge is regarding our UPSTREAM parent only. We are NOT retiring,
 <!---------------------------{ Badges }--------------------------->
 
 [Badge Guidelines]: https://img.shields.io/badge/Logo-Guidelines-d36e2d.svg?style=for-the-badge&labelColor=323232
-[Badge Retired]: https://img.shields.io/badge/Retired-bb3c1f.svg?style=for-the-badge&labelColor=323232&logoColor=white&logo=Atom
+[Badge Retired]: https://img.shields.io/badge/Retired-bb3c1f.svg?style=for-the-badge&labelColor=323232&label=Upstream%20Status
+[Badge Sunset]: https://img.shields.io/badge/Sunset-orange.svg?style=for-the-badge&labelColor=323232&label=Upstream%20Status
 [Badge Discord]: https://img.shields.io/badge/Discord-6399c4.svg?style=for-the-badge&labelColor=323232&logoColor=white&logo=Discord
 [Badge License]: https://img.shields.io/badge/License-MIT-e5ab42.svg?style=for-the-badge&labelColor=323232
 [Badge Status]: https://dev.azure.com/atomcommunity/atomcommunity/_apis/build/status/atom-community/Release%20Branch%20Build?branchName=master


### PR DESCRIPTION
Fixing the retirement badge for clarity to avoid confusion. Since it should be clear(until we rename/rebrand eventually) that it's not us retiring but upstream atom.