### PR TITLE
Change Windows Build image - 2016 -> 2019

### DIFF
--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -14,7 +14,7 @@ jobs:
           RunCoreMainTests: true
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]


### PR DESCRIPTION
The Windows 2016 image has been/will be deprecated as of today. https://github.com/actions/virtual-environments/issues/5403

Small update required to keep the CI running.