### PR TITLE
Add error condition + Expand timeout

### DIFF
--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1064,9 +1064,14 @@ describe('Project', () => {
           for (let event of events) {
             remaining.delete(event.path);
           }
+          clearTimeout(expireTimeoutId);
           if (remaining.size === 0) {
-            clearTimeout(expireTimeoutId);
             resolve();
+          } else {
+            console.error('Paths not seen:', remaining);
+            reject(
+              new Error('All events were processed but not all paths were seen.')
+            );
           }
         };
 
@@ -1078,7 +1083,7 @@ describe('Project', () => {
           );
         };
 
-        expireTimeoutId = setTimeout(expire, 2000);
+        expireTimeoutId = setTimeout(expire, 3000);
         checkCallback();
       });
     };

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1068,9 +1068,11 @@ describe('Project', () => {
           if (remaining.size === 0) {
             resolve();
           } else {
-            console.error('Paths not seen:', remaining);
+            const remainingStr = [...remaining].join('\n');
             reject(
-              new Error('All events were processed but not all paths were seen.')
+              new Error(
+                `All events were processed but not all paths were seen. Paths not seen: ${remainingStr}`
+              )
             );
           }
         };


### PR DESCRIPTION
One of the tests that fail in the newer windows. Edit: See #428 

If all paths are processed but not all paths were deleted out, the error is "expired", so I added an error condition to have it say "not all paths found" instead.

My instinct says this error condition probably isn't happening, but it would be nice to guarantee one way or other.

Expand timeout 2 --> 3 seconds

____

Edit: MacOS failed on the error condition I added somehow<s>??? It seems like all I'm doing is mapping some of one error into another,  but now that this happened I'm not sure what's going on.</s>

Theory: Previously, the if statement is skipped, the function returns, the promise resolves, and the test finishes before there's time for the setTimeout to error. But now there's the "else" statement causing an error. Don't know what's different about MacOS