### PR TITLE
package.json: Update "snippets" dependencies version to match packageDependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "open-on-github": "1.3.2",
     "package-generator": "1.3.0",
     "settings-view": "0.261.8",
-    "snippets": "1.5.1",
+    "snippets": "1.6.0",
     "spell-check": "0.77.1",
     "status-bar": "1.8.17",
     "styleguide": "0.49.12",


### PR DESCRIPTION
### Identify the Bug

Follow-up to https://github.com/atom-community/atom/pull/418.

<details><summary>Bug details (click to expand)</summary>

https://github.com/atom-community/atom/pull/418 updated the `packageDependencies:` version of the snippets package, but not the `dependencies:` version. (This works fine if running `apm ci`, like CI does. CI runs would not have detected this problem.)

The latest git commit of the community fork of the snippets package, as added to core's package.json in https://github.com/atom-community/atom/pull/418, has had its version bumped to 1.6.0 at some point. The core editor's `dependencies` version of snippets still says 1.5.1.

If running `apm install`, apm apparently notices the versions don't match, and overwrites it all with the "1.5.1" version listed in `dependencies`.

```console
$ apm install
Installing modules ✓
Installing snippets@1.5.1 ✓
```

That means folks running `script/bootstrap` or `script/build` at home will likely get the wrong version of snippets.

</details>

### Description of the Change

This PR makes sure the version of snippets listed in `dependencies`, and the one derived from `packageDependencies`, are matched up. This prevents apm from overwriting the newer snippets specified in https://github.com/atom-community/atom/pull/418 with older snippets 1.5.1 from the atom.io package registry.

(The snippets version under `dependencies` needs to be 1.6.0 now, since it was updated to 1.6.0 at snippets' git repo.)

### Verification Process

I manually ran `apm install` in the root of this repo before/after this change. I can confirm this stops apm overwriting the snippets package with 1.5.1 from the atom.io package registry. After this change, it uses the tarball of the git commit from the community fork of snippets, as intended from https://github.com/atom-community/atom/pull/418.

### Release Notes

N/A