### PR TITLE
Make GitHub Discussions link point to Atom Community and remove other support options

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,9 +1,6 @@
 # Atom Support
 
-If you're looking for support for Atom there are a lot of options, check out:
-
-* User Documentation &mdash; [The Atom Flight Manual](https://flight-manual.atom.io)
-* Developer Documentation &mdash; [Atom API Documentation](https://atom.io/docs/api/latest)
-* Message Board &mdash; [Github Discussions, the official Atom message board](https://github.com/atom/atom/discussions)
+If you're looking for support for Atom Community you can go to our message board linked below:
+* Message Board &mdash; [Github Discussions, the official Atom Community message board](https://github.com/atom-community/atom/discussions)
 
 On Atoms Github Discussions board, there are a bunch of helpful community members that should be willing to point you in the right direction.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Atom Support
  
-If you're looking for support for Atom Community you can go to our message board or Atom branded Flight manual linked below:
+If you're looking for support for Atom Community, you can go to our message board or the Flight manual linked below:
 * User Documentation &mdash; [The Atom Flight Manual](https://flight-manual.atom.io)
 * Message Board &mdash; [Github Discussions, the official Atom Community message board](https://github.com/atom-community/atom/discussions)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Atom Support
-
-If you're looking for support for Atom Community you can go to our message board or Atom brandedFlight manual linked below:
+ 
+If you're looking for support for Atom Community you can go to our message board or Atom branded Flight manual linked below:
 * User Documentation &mdash; [The Atom Flight Manual](https://flight-manual.atom.io)
 * Message Board &mdash; [Github Discussions, the official Atom Community message board](https://github.com/atom-community/atom/discussions)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,7 @@
 # Atom Support
 
-If you're looking for support for Atom Community you can go to our message board linked below:
+If you're looking for support for Atom Community you can go to our message board or Atom brandedFlight manual linked below:
+* User Documentation &mdash; [The Atom Flight Manual](https://flight-manual.atom.io)
 * Message Board &mdash; [Github Discussions, the official Atom Community message board](https://github.com/atom-community/atom/discussions)
 
 On Atoms Github Discussions board, there are a bunch of helpful community members that should be willing to point you in the right direction.


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change
Add the GitHub Discussions link for Atom-Community rather than Atom's repository
<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes
N/A
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->