### PR TITLE
deps: update packageDependencies entry for find-and-replace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6302,6 +6302,7 @@
     },
     "find-and-replace": {
       "version": "https://github.com/atom-community/find-and-replace/archive/refs/tags/v0.220.1.tar.gz",
+      "integrity": "sha512-lreq8kgz9Z+kTznBJW/4lhAcnpOBZHlMp3wX4QTOUYA9Dlhljz4HhViLI7+tJAcIQcXXHY4KD5NaVhUMs25IVQ==",
       "requires": {
         "binary-search": "^1.3.3",
         "etch": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "dev-live-reload": "file:./packages/dev-live-reload",
     "encoding-selector": "0.23.9",
     "exception-reporting": "file:./packages/exception-reporting",
-    "find-and-replace": "https://github.com/atom-community/find-and-replace/archive/refs/tags/v0.220.1.tar.gz",
+    "find-and-replace": "0.220.1",
     "fuzzy-finder": "1.14.3",
     "github": "0.36.10",
     "git-diff": "file:./packages/git-diff",


### PR DESCRIPTION
### Identify the Bug

Similar to https://github.com/atom-community/atom/pull/421. Misconfigured packageDependencies version for a package.

`packageDependencies` versions have to be a number `1.2.3` or a relative path `file:./path/to/package`. Otherwise, `apm install` complains and errors out.

#### Background Info

I believe the version specs in `packageDependencies` of package.json can only be:
- version numbers (`1.2.3-something`)
- or relative paths (`file:./packages/[package_name_here]`).

Due to limitations in apm's `install` command.

### Verification Process

Ran `script/bootstrap` and `apm install` commands locally. This PR fixes an error message:

```console
$ ./apm/node_modules/atom-package-manager/bin/apm install
Installing modules ✓
Installing find-and-replace@https://github.com/atom-community/find-and-replace/archive/refs/tags/v0.220.1.tar.gz ✗
Package version: https://github.com/atom-community/find-and-replace/archive/refs/tags/v0.220.1.tar.gz not found
```


Anyhow, yeah, here's the fix.