### PR TITLE
doc: Add binaries dashboard (install instructions)

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -42,7 +42,17 @@ sudo apt install git libasound2 libcurl4 libgbm1 libgcrypt20 libgtk-3-0 libnotif
 
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases. -->
+
 Currently, to get binaries based on code by the Atom community:
+
+1. Visit https://autumnblazey.github.io/atomcommunity-pipelines/ and click on a run to view available binaries.
+1. Click the desired binary for your platform to download. (If there is no binary for your platform, try viewing another run.)
+1. After the download is complete, extract the archive and run the executable.
+1. (Optional): To ensure you have a usable build, visit the associated CI run by clicking "(link to azure)".
+  - Select the job named after your OS (eg. _Linux_)
+  - At the bottom of the now visible log pane, make sure `100% tests passed` is visible
+
+OR
 
 1. browse our [_Release Branch Build_ Azure Pipeline](https://dev.azure.com/atomcommunity/atomcommunity/_build/latest?definitionId=10&branchName=master);
 2. select the Job named after your OS (eg. _Linux_);


### PR DESCRIPTION
## Context

Following up on discussion in https://github.com/atom-community/atom/pull/456.

### Description of the Change

Add link to a nice binaries dashboard to the Installation.md instructions.

(Dashboard is originally by @autumnblazey, but not maintained by them anymore. atom-community org is welcome to fork the dashboard repo if there is a need to make updates.)

### Release Notes

N/A