### PR TITLE
Fix "Upload Artifacts" job in CI (makes CI pass)

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,8 +1,6 @@
 # workaround for https://bit.ly/2CK8itc
 variables:
-  _ATOM_RELEASES_S3_KEY:  $[ variables.ATOM_RELEASES_S3_KEY ]
-  _ATOM_RELEASES_S3_SECRET:  $[ variables.ATOM_RELEASES_S3_SECRET ]
-  _ATOM_RELEASES_S3_BUCKET: $[ variables.ATOM_RELEASES_S3_BUCKET ]
+  _ATOM_RELEASES_AZURE_CONN_STRING: $[ variables.ATOM_RELEASES_AZURE_CONN_STRING ]
   _PACKAGE_CLOUD_API_KEY: $[ variables.PACKAGE_CLOUD_API_KEY ]
 
 jobs:
@@ -49,11 +47,8 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_AZURE_CONN_STRING: $(ATOM_RELEASES_AZURE_CONN_STRING)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-          PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
+          ATOM_RELEASES_AZURE_CONN_STRING: $(_ATOM_RELEASES_AZURE_CONN_STRING)
+          PACKAGE_CLOUD_API_KEY: $(_PACKAGE_CLOUD_API_KEY)
         displayName: Create Nightly Release
   - job: bump_dependencies
     displayName: Bump Dependencies

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,4 +1,4 @@
-# workaround for https://bit.ly/2CK8itc
+# workaround for https://developercommunity.visualstudio.com/t/inconsistent-behavior-between-variablessecretvar-a/1151302
 variables:
   _ATOM_RELEASES_AZURE_CONN_STRING: $[ variables.ATOM_RELEASES_AZURE_CONN_STRING ]
   _PACKAGE_CLOUD_API_KEY: $[ variables.PACKAGE_CLOUD_API_KEY ]

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -6,9 +6,7 @@ pr: none # no PR triggers
 
 # workaround for https://bit.ly/2CK8itc
 variables:
-  _ATOM_RELEASES_S3_KEY:  $[ variables.ATOM_RELEASES_S3_KEY ]
-  _ATOM_RELEASES_S3_SECRET:  $[ variables.ATOM_RELEASES_S3_SECRET ]
-  _ATOM_RELEASES_S3_BUCKET: $[ variables.ATOM_RELEASES_S3_BUCKET ]
+  _ATOM_RELEASES_AZURE_CONN_STRING:  $[ variables.ATOM_RELEASES_AZURE_CONN_STRING ]
   _PACKAGE_CLOUD_API_KEY: $[ variables.PACKAGE_CLOUD_API_KEY ]
 
 jobs:
@@ -53,11 +51,8 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_AZURE_CONN_STRING: $(ATOM_RELEASES_AZURE_CONN_STRING)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-          PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
+          ATOM_RELEASES_AZURE_CONN_STRING: $(_ATOM_RELEASES_AZURE_CONN_STRING)
+          PACKAGE_CLOUD_API_KEY: $(_PACKAGE_CLOUD_API_KEY)
         displayName: Create Draft Release
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
@@ -65,9 +60,6 @@ jobs:
           node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --azure-blob-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_AZURE_CONN_STRING: $(ATOM_RELEASES_AZURE_CONN_STRING)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ATOM_RELEASES_AZURE_CONN_STRING: $(_ATOM_RELEASES_AZURE_CONN_STRING)
         displayName: Upload CI Artifacts to S3
         condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -4,7 +4,7 @@ trigger:
   - electron-*
 pr: none # no PR triggers
 
-# workaround for https://bit.ly/2CK8itc
+# workaround for https://developercommunity.visualstudio.com/t/inconsistent-behavior-between-variablessecretvar-a/1151302
 variables:
   _ATOM_RELEASES_AZURE_CONN_STRING:  $[ variables.ATOM_RELEASES_AZURE_CONN_STRING ]
   _PACKAGE_CLOUD_API_KEY: $[ variables.PACKAGE_CLOUD_API_KEY ]

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -75,7 +75,7 @@ async function uploadArtifacts() {
     );
   } else {
     console.log(
-      '\nEnvironment variable "process.env.ATOM_RELEASES_AZURE_CONN_STRING," is not set, skipping Azure upload.'
+      '\nEnvironment variable "process.env.ATOM_RELEASES_AZURE_CONN_STRING" is not set, skipping Azure upload.'
     );
   }
 

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -62,9 +62,7 @@ async function uploadArtifacts() {
   }
 
   if (
-    process.env.ATOM_RELEASES_S3_KEY &&
-    process.env.ATOM_RELEASES_S3_SECRET &&
-    process.env.ATOM_RELEASES_S3_BUCKET
+    process.env.ATOM_RELEASES_AZURE_CONN_STRING
   ) {
     console.log(
       `Uploading ${
@@ -79,7 +77,7 @@ async function uploadArtifacts() {
     );
   } else {
     console.log(
-      '\nEnvironment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+      '\nEnvironment variable "process.env.ATOM_RELEASES_AZURE_CONN_STRING," is not set, skipping Azure upload.'
     );
   }
 

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -61,9 +61,7 @@ async function uploadArtifacts() {
     return;
   }
 
-  if (
-    process.env.ATOM_RELEASES_AZURE_CONN_STRING
-  ) {
+  if (process.env.ATOM_RELEASES_AZURE_CONN_STRING) {
     console.log(
       `Uploading ${
         assets.length


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

CI isn't passing, because it tries to upload binary blobs to Azure Storage, but without the needed credentials. This errors out, causing CI to fail (even after the build and tests may have succeeded.)

### Description of the Change

- Update [`script/vsts/upload-artifacts.js`](https://github.com/atom-community/atom/blob/master/script/vsts/upload-artifacts.js) to skip uploading binary blobs to Azure Storage if env var `ATOM_RELEASES_AZURE_CONN_STRING` is unset or empty (more precisely: if it is falsy in JS).
- Update the "Upload CI Artifacts" job in the CI YAML files so that it uses the intermediate variables workaround, which makes sure env vars will be seen as undefined/empty in scripts.
  - This is restoring a part of the solution we had before (from https://github.com/atom-community/atom/pull/99), but I think it got reverted during a merge of upstream commits at some point?
- Use unshortened URL in the comment explaining the workaround
  - (This is an optional change, not super important. Just my personal preference.)

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

CI should pass if this PR is done right.

**NOTE**: The PR pipeline will not test this change. I will manually run the release branch pipeline on my personal CI instance to see if it passes. CI passing directly on this PR will be the "Pull Requests" pipeline, which has nothing to do with this change.

### Release Notes

N/A