### PR TITLE
apm: Update to v2.6.5-atomic.1.1

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,8 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "npm:@atom-ide-community/atom-package-manager@2.6.5-atomic.1.0",
-      "resolved": "https://registry.npmjs.org/@atom-ide-community/atom-package-manager/-/atom-package-manager-2.6.5-atomic.1.0.tgz",
-      "integrity": "sha512-6plCUJpj90T4JhLtrADS2v8oi8HxQSFa7f82VWg4I40Os43La8Gsd/gMgAmIxgeBkbt3qXlI6cZvpDiDxQmlmg==",
+      "version": "https://github.com/atom-community/apm/archive/3952d49a1c505f79f6e9cd52d69aecb99c76a1d0.tar.gz",
+      "integrity": "sha512-rYJV54BFzKoTMAyYZbOfphayYqmsSYnBw3ybyzqd6eBs1e3yBoVK5Vyh5J1cj5mbMiXJy6iCx0SmUtuL8JlEkA==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",
@@ -132,9 +131,9 @@
           "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
         },
         "aws4": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-          "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "balanced-match": {
           "version": "1.0.2",
@@ -392,9 +391,9 @@
           }
         },
         "es5-ext": {
-          "version": "0.10.61",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-          "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+          "version": "0.10.62",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
           "requires": {
             "es6-iterator": "^2.0.3",
             "es6-symbol": "^3.1.3",
@@ -472,17 +471,17 @@
           "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
         },
         "ext": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-          "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+          "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
           "requires": {
-            "type": "^2.5.0"
+            "type": "^2.7.2"
           },
           "dependencies": {
             "type": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-              "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+              "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
             }
           }
         },
@@ -568,6 +567,16 @@
           "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "requires": {
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+              "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "fs-plus": {
@@ -845,14 +854,14 @@
           }
         },
         "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
         },
         "minipass": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-          "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -864,6 +873,16 @@
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+              "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "mixto": {
@@ -937,9 +956,9 @@
           }
         },
         "nan": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-          "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
         },
         "napi-build-utils": {
           "version": "1.0.2",
@@ -957,9 +976,9 @@
           "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
         },
         "node-abi": {
-          "version": "3.22.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.22.0.tgz",
-          "integrity": "sha512-u4uAs/4Zzmp/jjsD9cyFYDXeISfUWaAVWshPmDZOFOv4Xl4SbzTXm53I04C2uRueYJ+0t5PEtLH/owbn2Npf/w==",
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.31.0.tgz",
+          "integrity": "sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==",
           "requires": {
             "semver": "^7.3.5"
           }
@@ -978,9 +997,9 @@
           }
         },
         "npm": {
-          "version": "6.14.17",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.17.tgz",
-          "integrity": "sha512-CxEDn1ydVRPDl4tHrlnq+WevYAhv4GF2AEHzJKQ4prZDZ96IS3Uo6t0Sy6O9kB6XzqkI+J00WfYCqqk0p6IJ1Q==",
+          "version": "6.14.18",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.18.tgz",
+          "integrity": "sha512-p3SjqSchSuNQUqbJBgwdv0L3O6bKkaSfQrQzJsskNpNKLg0g37c5xTXFV0SqTlX9GWvoGxBELVJMRWq0J8oaLA==",
           "requires": {
             "JSONStream": "^1.3.5",
             "abbrev": "~1.1.1",
@@ -989,9 +1008,9 @@
             "aproba": "^2.0.0",
             "archy": "~1.0.0",
             "bin-links": "^1.1.8",
-            "bluebird": "^3.5.5",
+            "bluebird": "^3.7.2",
             "byte-size": "^5.0.1",
-            "cacache": "^12.0.3",
+            "cacache": "^12.0.4",
             "call-limit": "^1.1.1",
             "chownr": "^1.1.4",
             "ci-info": "^2.0.0",
@@ -999,19 +1018,19 @@
             "cli-table3": "^0.5.1",
             "cmd-shim": "^3.0.3",
             "columnify": "~1.5.4",
-            "config-chain": "^1.1.12",
+            "config-chain": "^1.1.13",
             "debuglog": "*",
             "detect-indent": "~5.0.0",
             "detect-newline": "^2.1.0",
-            "dezalgo": "~1.0.3",
+            "dezalgo": "^1.0.4",
             "editor": "~1.0.0",
-            "figgy-pudding": "^3.5.1",
+            "figgy-pudding": "^3.5.2",
             "find-npm-prefix": "^1.0.2",
             "fs-vacuum": "~1.2.10",
             "fs-write-stream-atomic": "~1.0.10",
             "gentle-fs": "^2.3.1",
-            "glob": "^7.1.6",
-            "graceful-fs": "^4.2.4",
+            "glob": "^7.2.3",
+            "graceful-fs": "^4.2.10",
             "has-unicode": "~2.0.1",
             "hosted-git-info": "^2.8.9",
             "iferr": "^1.0.2",
@@ -1021,7 +1040,7 @@
             "inherits": "^2.0.4",
             "ini": "^1.3.8",
             "init-package-json": "^1.10.3",
-            "is-cidr": "^3.0.0",
+            "is-cidr": "^3.1.1",
             "json-parse-better-errors": "^1.0.2",
             "lazy-property": "~1.0.0",
             "libcipm": "^4.0.8",
@@ -1032,7 +1051,7 @@
             "libnpmsearch": "^2.0.2",
             "libnpmteam": "^1.0.2",
             "libnpx": "^10.2.4",
-            "lock-verify": "^2.1.0",
+            "lock-verify": "^2.2.2",
             "lockfile": "^1.0.4",
             "lodash._baseindexof": "*",
             "lodash._baseuniq": "~4.6.0",
@@ -1046,11 +1065,11 @@
             "lodash.uniq": "~4.5.0",
             "lodash.without": "~4.4.0",
             "lru-cache": "^5.1.1",
-            "meant": "^1.0.2",
+            "meant": "^1.0.3",
             "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.5",
+            "mkdirp": "^0.5.6",
             "move-concurrently": "^1.0.1",
-            "node-gyp": "^5.1.0",
+            "node-gyp": "^5.1.1",
             "nopt": "^4.0.3",
             "normalize-package-data": "^2.5.0",
             "npm-audit-report": "^1.3.3",
@@ -1071,19 +1090,19 @@
             "path-is-inside": "~1.0.2",
             "promise-inflight": "~1.0.1",
             "qrcode-terminal": "^0.12.0",
-            "query-string": "^6.8.2",
-            "qw": "~1.0.1",
+            "query-string": "^6.14.1",
+            "qw": "^1.0.2",
             "read": "~1.0.7",
             "read-cmd-shim": "^1.0.5",
             "read-installed": "~4.0.3",
-            "read-package-json": "^2.1.1",
+            "read-package-json": "^2.1.2",
             "read-package-tree": "^5.3.1",
             "readable-stream": "^3.6.0",
             "readdir-scoped-modules": "^1.1.0",
-            "request": "^2.88.0",
+            "request": "^2.88.2",
             "retry": "^0.12.0",
             "rimraf": "^2.7.1",
-            "safe-buffer": "^5.1.2",
+            "safe-buffer": "^5.2.1",
             "semver": "^5.7.1",
             "sha": "^3.0.0",
             "slide": "~1.1.6",
@@ -1099,7 +1118,7 @@
             "unique-filename": "^1.1.1",
             "unpipe": "~1.0.0",
             "update-notifier": "^2.5.0",
-            "uuid": "^3.3.3",
+            "uuid": "^3.4.0",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "~3.0.0",
             "which": "^1.3.1",
@@ -1107,6 +1126,14 @@
             "write-file-atomic": "^2.4.3"
           },
           "dependencies": {
+            "@iarna/cli": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.1.2",
+                "signal-exit": "^3.0.2"
+              }
+            },
             "JSONStream": {
               "version": "1.3.5",
               "bundled": true,
@@ -1186,6 +1213,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1193,6 +1226,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -1202,7 +1241,7 @@
               "bundled": true
             },
             "asn1": {
-              "version": "0.2.4",
+              "version": "0.2.6",
               "bundled": true,
               "requires": {
                 "safer-buffer": "~2.1.0"
@@ -1221,17 +1260,16 @@
               "bundled": true
             },
             "aws4": {
-              "version": "1.8.0",
+              "version": "1.11.0",
               "bundled": true
             },
             "balanced-match": {
-              "version": "1.0.0",
+              "version": "1.0.2",
               "bundled": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "tweetnacl": "^0.14.3"
               }
@@ -1249,7 +1287,7 @@
               }
             },
             "bluebird": {
-              "version": "3.5.5",
+              "version": "3.7.2",
               "bundled": true
             },
             "boxen": {
@@ -1290,7 +1328,7 @@
               "bundled": true
             },
             "cacache": {
-              "version": "12.0.3",
+              "version": "12.0.4",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.5",
@@ -1447,7 +1485,7 @@
               }
             },
             "combined-stream": {
-              "version": "1.0.6",
+              "version": "1.0.8",
               "bundled": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -1478,6 +1516,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1485,12 +1529,18 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
             },
             "config-chain": {
-              "version": "1.1.12",
+              "version": "1.1.13",
               "bundled": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -1606,7 +1656,7 @@
               "bundled": true
             },
             "decode-uri-component": {
-              "version": "0.2.0",
+              "version": "0.2.2",
               "bundled": true
             },
             "deep-extend": {
@@ -1644,7 +1694,7 @@
               "bundled": true
             },
             "dezalgo": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "bundled": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -1687,6 +1737,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1694,6 +1750,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -1701,7 +1763,6 @@
             "ecc-jsbn": {
               "version": "0.1.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -1730,7 +1791,7 @@
               }
             },
             "env-paths": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "bundled": true
             },
             "err-code": {
@@ -1811,7 +1872,11 @@
               "bundled": true
             },
             "figgy-pudding": {
-              "version": "3.5.1",
+              "version": "3.5.2",
+              "bundled": true
+            },
+            "filter-obj": {
+              "version": "1.1.0",
               "bundled": true
             },
             "find-npm-prefix": {
@@ -1837,6 +1902,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1844,6 +1915,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -1853,11 +1930,11 @@
               "bundled": true
             },
             "form-data": {
-              "version": "2.3.2",
+              "version": "2.3.3",
               "bundled": true,
               "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
+                "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
               }
             },
@@ -1880,6 +1957,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1887,6 +1970,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -1942,6 +2031,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -1949,6 +2044,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -2040,15 +2141,24 @@
               }
             },
             "glob": {
-              "version": "7.1.6",
+              "version": "7.2.3",
               "bundled": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.1",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
               }
             },
             "global-dirs": {
@@ -2082,7 +2192,7 @@
               }
             },
             "graceful-fs": {
-              "version": "4.2.4",
+              "version": "4.2.10",
               "bundled": true
             },
             "har-schema": {
@@ -2262,7 +2372,7 @@
               }
             },
             "is-cidr": {
-              "version": "3.0.0",
+              "version": "3.1.1",
               "bundled": true,
               "requires": {
                 "cidr-regex": "^2.0.10"
@@ -2346,11 +2456,14 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "json-parse-better-errors": {
               "version": "1.0.2",
+              "bundled": true
+            },
+            "json-parse-even-better-errors": {
+              "version": "2.3.1",
               "bundled": true
             },
             "json-schema": {
@@ -2556,9 +2669,10 @@
               }
             },
             "lock-verify": {
-              "version": "2.1.0",
+              "version": "2.2.2",
               "bundled": true,
               "requires": {
+                "@iarna/cli": "^2.1.0",
                 "npm-package-arg": "^6.1.0",
                 "semver": "^5.4.1"
               }
@@ -2665,7 +2779,7 @@
               }
             },
             "meant": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "bundled": true
             },
             "mime-db": {
@@ -2680,7 +2794,7 @@
               }
             },
             "minimatch": {
-              "version": "3.0.4",
+              "version": "3.1.2",
               "bundled": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -2724,16 +2838,10 @@
               }
             },
             "mkdirp": {
-              "version": "0.5.5",
+              "version": "0.5.6",
               "bundled": true,
               "requires": {
-                "minimist": "^1.2.5"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.6",
-                  "bundled": true
-                }
+                "minimist": "^1.2.6"
               }
             },
             "move-concurrently": {
@@ -2772,7 +2880,7 @@
               }
             },
             "node-gyp": {
-              "version": "5.1.0",
+              "version": "5.1.1",
               "bundled": true,
               "requires": {
                 "env-paths": "^2.2.0",
@@ -3071,6 +3179,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -3078,6 +3192,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -3163,7 +3283,7 @@
               "bundled": true
             },
             "psl": {
-              "version": "1.1.29",
+              "version": "1.9.0",
               "bundled": true
             },
             "pump": {
@@ -3193,29 +3313,26 @@
                 }
               }
             },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
             "qrcode-terminal": {
               "version": "0.12.0",
               "bundled": true
             },
             "qs": {
-              "version": "6.5.2",
+              "version": "6.5.3",
               "bundled": true
             },
             "query-string": {
-              "version": "6.8.2",
+              "version": "6.14.1",
               "bundled": true,
               "requires": {
                 "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
                 "split-on-first": "^1.0.0",
                 "strict-uri-encode": "^2.0.0"
               }
             },
             "qw": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true
             },
             "rc": {
@@ -3256,12 +3373,11 @@
               }
             },
             "read-package-json": {
-              "version": "2.1.1",
+              "version": "2.1.2",
               "bundled": true,
               "requires": {
                 "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
+                "json-parse-even-better-errors": "^2.3.0",
                 "normalize-package-data": "^2.0.0",
                 "npm-normalize-package-bin": "^1.0.0"
               }
@@ -3310,7 +3426,7 @@
               }
             },
             "request": {
-              "version": "2.88.0",
+              "version": "2.88.2",
               "bundled": true,
               "requires": {
                 "aws-sign2": "~0.7.0",
@@ -3320,7 +3436,7 @@
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
                 "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
@@ -3330,7 +3446,7 @@
                 "performance-now": "^2.1.0",
                 "qs": "~6.5.2",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
               }
@@ -3372,7 +3488,7 @@
               }
             },
             "safe-buffer": {
-              "version": "5.1.2",
+              "version": "5.2.1",
               "bundled": true
             },
             "safer-buffer": {
@@ -3518,7 +3634,7 @@
               "bundled": true
             },
             "sshpk": {
-              "version": "1.14.2",
+              "version": "1.17.0",
               "bundled": true,
               "requires": {
                 "asn1": "~0.2.3",
@@ -3566,6 +3682,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -3573,6 +3695,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -3714,6 +3842,12 @@
                     "safe-buffer": "~5.1.1",
                     "string_decoder": "~1.1.1",
                     "util-deprecate": "~1.0.1"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 },
                 "string_decoder": {
@@ -3721,6 +3855,12 @@
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
+                  },
+                  "dependencies": {
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -3734,11 +3874,17 @@
               "bundled": true
             },
             "tough-cookie": {
-              "version": "2.4.3",
+              "version": "2.5.0",
               "bundled": true,
               "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
               }
             },
             "tunnel-agent": {
@@ -3750,8 +3896,7 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "typedarray": {
               "version": "0.0.6",
@@ -3811,7 +3956,7 @@
               }
             },
             "uri-js": {
-              "version": "4.4.0",
+              "version": "4.4.1",
               "bundled": true,
               "requires": {
                 "punycode": "^2.1.0"
@@ -3846,7 +3991,7 @@
               }
             },
             "uuid": {
-              "version": "3.3.3",
+              "version": "3.4.0",
               "bundled": true
             },
             "validate-npm-package-license": {
@@ -4180,9 +4325,9 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+          "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         },
         "q": {
           "version": "1.5.1",
@@ -4280,9 +4425,9 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4347,13 +4492,13 @@
           "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         },
         "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "version": "6.1.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+          "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
+            "minipass": "^4.0.0",
             "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
@@ -4492,9 +4637,9 @@
           "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
         },
         "underscore": {
-          "version": "1.13.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-          "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+          "version": "1.13.6",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "underscore-plus": {
           "version": "1.7.0",

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "npm:@atom-ide-community/atom-package-manager@2.6.5-atomic.1.0"
+    "atom-package-manager": "https://github.com/atom-community/apm/archive/3952d49a1c505f79f6e9cd52d69aecb99c76a1d0.tar.gz"
   }
 }


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing a Bug Fix</b> (click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Includes this fix (https://github.com/atom-community/apm/pull/124) so apm's bundled copy of node-gyp can download the 'headers' tarball needed to compile native C/C++ addons.

See another PR that did the same thing at an apm fork for more explanation: https://github.com/pulsar-edit/ppm/pull/43

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- **Bump apm to the latest version.**
  - Includes https://github.com/atom-community/apm/pull/124 that helps apm compile native C/C++ addons after the sunset.
  - Had to get apm off of GitHub, since I don't have credentials to publish the apm package to the npm registry. Prepared a commit (https://github.com/atom-community/apm/commit/3952d49a1c505f79f6e9cd52d69aecb99c76a1d0) at apm's git repo where there are no un-needed files, and specified this commit as a GitHub.com _tarball_ URL, so there should be no practical difference from getting the package tarball implicitly from the npm package registry vs this tarball from apm's GitHub repo.
  - Also bumps apm's dependencies, such as npm to the latest 6.14.18, since any time you change any given dependency, `npm install` automatically fetches the latest sub-dependencies under that dependency.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Could do this same apm update but keep all the sub-dependencies unchanged (for a more minimalist change).

I ran the Atom repo's CI tests, and there was no difference in terms of passing or failing Atom tests, so I don't see the point in staying on the older sub-dependencies. Might as well get the latest npm 6.x, in my opinion.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

N/A, nothing I am aware of. It's a one-line fix in apm, from a fully dead URL (atom.io has been sunset) to a live one.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

CI passes 100% at the apm repo, and no _new_ tests fail here.

In fact, the only failing test here ( [one failing assert in the `settings-view` package tests](https://github.com/atom/settings-view/blob/94418d66db1bbbd2f2d36fe90387506d13f65aab/spec/package-detail-view-spec.coffee#L102)) happens also on `master` branch without this fix (if you can get `master` branch to even build, that is! https://github.com/atom-community/apm/pull/124 fixes an issue that can prevent you building Atom if you don't know how to work around it!).

I was even able to build upstream Atom, and reproduce the failing CI test with that built version of Atom, and with official Atom 1.60.0 (the last version with Electron 9, which I consider the most stable upstream Atom release).

So, the CI failure is _unrelated_. Everything else passes in CI.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A

### Commit Message

<details><summary>Commit message with more notes (click to expand):</summary>

Includes an updated Electron headers dist URL, as the atom.io one is now down as a result of the Atom sunset.

Should allow apm to build native C/C++ packages again.

NOTE:
Fetching apm from its GitHub repo directly, instead of from the npm package registry as before, as I do not have access to publish the '@atom-ide-community/atom-package-manager' package to the npm package registry.

This is the next best option. The commit this is pointing to has been prepared equivalently to the process for uploading to the npm package registry, by running `npm install` and `npm pack`, extracting the resulting tarball, and committing (only) the result of those operations.

Essentially pre-compiles the .coffee src/ files into .js lib/ files, and prunes out a lot of un-needed files for Atom's purposes, such as all the specs. Again, this is equivalent to how apm would be packaged if I had been able to upload it to the npm package registry.

NOTE:
The commit this points to at the 'atom-community/apm' repo is the commit at the tip of the '2.6.5-atomic.1.1-dist' branch at that repo, as of the time this commit is being authored (28th January 2023).

NOTE:
Using a full git SHA so that this is content-addressable, and the file content cannot change. Either this SHA is available at the git repo, and the exact same file content can be downloaded from there, or the `npm install` will fail. (Failing to install would be better than surreptitiously downloading/running different/unexpected code.)

This is a best practice, in my opinion, when specifying dependencies from a remote git repo, as the lockfile 'integrity' field is easier to overlook when it changes, whereas this needs the exact SHA available, or it will outright fail. Branches and tags are *not* immutable. SHAs *are* immutable (barring some rather exotic hash collision attack).

</details>