### PR TITLE
docs: Update URL for the CI (binaries) dashboard

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -45,7 +45,7 @@ repeat these steps to upgrade to future releases. -->
 
 Currently, to get binaries based on code by the Atom community:
 
-1. Visit https://autumnblazey.github.io/atomcommunity-pipelines/ and click on a run to view available binaries.
+1. Visit https://atom-community.github.io/atomcommunity-pipelines/ and click on a run to view available binaries.
 1. Click the desired binary for your platform to download. (If there is no binary for your platform, try viewing another run.)
 1. After the download is complete, extract the archive and run the executable.
 1. (Optional): To ensure you have a usable build, visit the associated CI run by clicking "(link to azure)".


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing Documentation</b> (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

</details>

### Description of the Change

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

This makes the first half of the Installation docs followable again.

The old link went down, and while a redirect would be possible, the atom-community org's forked version of the repo has deployed a fix that isn't deployed at the original, and besides, we may as well bring this resource into being officially hosted by the atom-community org, rather than have it be maintained/hosted primarily on a personal account, I suppose.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A